### PR TITLE
refine nodesDB handling and writing of default db

### DIFF
--- a/lib/BtLog.py
+++ b/lib/BtLog.py
@@ -79,8 +79,8 @@ error_d = {
     '43': '[ERROR:43] : %s could not be found.',
     '44': '[ERROR:44] : Please specify integers for --map_col_sseqid and --map_col_taxid.',
     '45': '[ERROR:45] : Both --min_score and --min_diff must be numbers.',
-    '46': '[ERROR:46] : Score in %s must be a float, not \'%s\'.'
-
+    '46': '[ERROR:46] : Score in %s must be a float, not \'%s\'.',
+    '47': '[ERROR:47] : Cannot create new "--db" file from "--names", "--nodes", "--db" file exists. %s'
 }
 
 warn_d = {
@@ -125,7 +125,9 @@ status_d = {
     '23': '[+] Filtered %s (pairs=%s) ...',
     '24': '[+] Writing %s',
     '25': '[+] Gzip\'ing %s',
-    '26': '[+] Reading %s'
+    '26': '[+] Reading %s',
+    '27': '[+] Creating nodesDB %s from %s and %s',
+    '28': '[+] Store nodesDB in %s',
 }
 
 info_d = {

--- a/lib/create.py
+++ b/lib/create.py
@@ -32,7 +32,8 @@
                                         taxonomies have equal scores (otherwise "unresolved") [default: False]
         --nodes <NODES>                 NCBI nodes.dmp file. Not required if '--db'
         --names <NAMES>                 NCBI names.dmp file. Not required if '--db'
-        --db <NODESDB>                  NodesDB file (default: $BLOBTOOLS/data/nodesDB.txt).
+        --db <NODESDB>                  NodesDB file (default: $BLOBTOOLS/data/nodesDB.txt).  If --nodes, --names and --db
+                                        are all given and NODESDB does not exist, create it from NODES and NAMES.
         -b, --bam <BAM>...              BAM file(s), can be specified multiple times
         -s, --sam <SAM>...              SAM file(s), can be specified multiple times
         -a, --cas <CAS>...              CAS file(s) (requires clc_mapping_info in $PATH), can be specified multiple times


### PR DESCRIPTION
We have blobtools installed in a cluster environment, where creation of the default taxonomy db is possible during installation by someone with sufficient permissions, but not by users loading blobtools as a module.  There is also no facility for creating a taxonomy db in some location other than the default, although it is possible to load a taxonomy db from another location with `--db`.

This pull request modified `blobtools create` a bit to allow creation of a taxonomy db when `--nodes`, `--names`, and `--db` are all specified and the taxonomy db named by `--db` does not exist.  In that case, there is no attempt to create the default database, only the named database.