### PR TITLE
fix ParsedRequirement object has no attribute 'req'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 # get the dependencies and installs
 install_reqs = parse_requirements(path.join(here, 'requirements.txt'), session=False)
-reqs = [str(ir.req) for ir in install_reqs]
+
+try:
+    reqs = [str(ir.req) for ir in install_reqs]
+except AttributeError:
+    reqs = [str(ir.requirement) for ir in install_reqs]
 
 class OverrideInstall(install):
 


### PR DESCRIPTION
fallback to use ParsedRequirement.requirement if the setup.py fails with an attribute error.

tested with:
* python 2.7.15
* python 3.6.3 
* python 3.8.5

how to replicate:

```
git clone https://github.com/DRL/blobtools
cd blobtools
python setup.py install --user
```

error:

```
Traceback (most recent call last):
  File "setup.py", line 18, in <module>
    reqs = [str(ir.req) for ir in install_reqs]
  File "setup.py", line 18, in <listcomp>
    reqs = [str(ir.req) for ir in install_reqs]
AttributeError: 'ParsedRequirement' object has no attribute 'req'
```

supporting docs: https://stackoverflow.com/questions/62114945/attributeerror-parsedrequirement-object-has-no-attribute-req